### PR TITLE
Add post-install welcome script and systemd repair utilities

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12
+  },
+  "rules": {}
+}

--- a/scripts/fix-systemd.sh
+++ b/scripts/fix-systemd.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to repair existing Micromanager systemd units that used the `ptty` typo.
+# It searches for unit files containing "ptty" and renames/reloads them with
+# the correct "tty" naming.
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [[ $EUID -ne 0 ]]; then
+  echo -e "${RED}This script must be run as root${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Checking for misnamed systemd units...${NC}"
+
+shopt -s nullglob
+for file in /etc/systemd/system/micromanager@ptty*.service; do
+  corrected="${file/ptty/tty}"
+  echo -e "${YELLOW}Fixing ${file} -> ${corrected}${NC}"
+  sed -i 's/ptty/tty/g' "$file"
+  mv "$file" "$corrected"
+  systemctl disable "$(basename "$file" .service)" >/dev/null 2>&1 || true
+  systemctl enable "$(basename "$corrected" .service)" >/dev/null 2>&1 || true
+  systemctl restart "$(basename "$corrected" .service)" >/dev/null 2>&1 || true
+  echo -e "${GREEN}✓ Corrected and restarted $(basename "$corrected")${NC}"
+
+done
+
+systemctl daemon-reload
+
+echo -e "${GREEN}Systemd units updated.${NC}"

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('Micromanager installed. Run scripts/dual-setup.sh to configure dual tty instances.');
+

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,4 +1,2 @@
 #!/usr/bin/env node
-
-console.log('Micromanager installed. Run scripts/dual-setup.sh to configure dual tty instances.');
-
+console.log('Micromanager installed. Run scripts/dual-setup.sh to configure dual instances.');


### PR DESCRIPTION
## Summary
- fix welcome message typo referencing dual tty setup
- add ESLint configuration file so `npm run lint` no longer fails due to missing config
- add `fix-systemd.sh` helper to repair existing service files with the `ptty` typo

## Testing
- `npm install`
- `npm test` *(fails: 7 failed, 43 passed, 50 total)*
- `npm run lint` *(fails: Parsing error in DeviceInitializer.js)*

------
https://chatgpt.com/codex/tasks/task_e_68980ae6bdac8324916ff9d1ab73059d