### PR TITLE
Add port-specific device IDs and default webhook for dual setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "es2022": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 2022
+  },
+  "rules": {}
+}

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ curl http://localhost:3000/health
 The micromanager automatically generates a unique device ID on first run:
 
 ```bash
-# Device ID format: mmd-rv1-{last6MAC}
-# Example: mmd-rv1-ddeeff (from MAC aa:bb:cc:dd:ee:ff)
+# Device ID format: mmd-rv1-{last6MAC}-{port}
+# Example: mmd-rv1-ddeeff-0 (from MAC aa:bb:cc:dd:ee:ff on ttyUSB0)
 ```
 
 Configuration is stored in `config/device.json`:
 
 ```json
 {
-  "deviceId": "mmd-rv1-ddeeff",
+  "deviceId": "mmd-rv1-ddeeff-0",
   "deviceName": "POS Terminal 101",
   "posType": "verifone_commander",
   "n8nWebhookUrl": "https://n8n.yourserver.com/webhook/parse-pos-line",
@@ -130,7 +130,7 @@ Each POS line is sent to your n8n webhook as:
 
 ```json
 {
-  "micromanager_id": "mmd-rv1-ddeeff",
+  "micromanager_id": "mmd-rv1-ddeeff-0",
   "device_name": "POS Terminal 101",
   "pos_type": "verifone_commander",
   "raw_line": "07/11/25 03:33:19 102 COCA COLA 1 2.50",
@@ -143,10 +143,10 @@ Each POS line is sent to your n8n webhook as:
 
 ```
 Content-Type: application/json
-X-Device-ID: mmd-rv1-ddeeff
+X-Device-ID: mmd-rv1-ddeeff-0
 X-Device-Name: POS Terminal 101
 X-POS-Type: verifone_commander
-User-Agent: SimplifiedMicromanager/mmd-rv1-ddeeff
+User-Agent: SimplifiedMicromanager/mmd-rv1-ddeeff-0
 ```
 
 ## 🛡️ Reliability Features

--- a/scripts/dual-setup.sh
+++ b/scripts/dual-setup.sh
@@ -76,7 +76,7 @@ for PORT in "${PORTS[@]}"; do
   if [[ ! -f "$ENV_FILE" ]]; then
     cat > "$ENV_FILE" <<ENVEOF
 SERIAL_PORT=/dev/$PORT
-N8N_WEBHOOK_URL=https://example.com/webhook-$PORT
+N8N_WEBHOOK_URL=https://n8n-vcni0-u35184.vm.elestio.app/webhook/parse-pos-line
 DEVICE_NAME=register-$PORT
 ENVEOF
     echo -e "${GREEN}✓ Created $ENV_FILE${NC}"

--- a/scripts/fix-config-perms.sh
+++ b/scripts/fix-config-perms.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Repair permissions for Micromanager config directory
+# Ensures /opt/micromanager-pos/config is writable by the service user
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SERVICE_USER="micromanager"
+CONFIG_DIR="/opt/micromanager-pos/config"
+
+if [[ $EUID -ne 0 ]]; then
+  echo -e "${RED}This script must be run as root${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Ensuring config directory exists and is writable...${NC}"
+mkdir -p "$CONFIG_DIR"
+chown -R "$SERVICE_USER:$SERVICE_USER" "$CONFIG_DIR"
+chmod 755 "$CONFIG_DIR"
+
+echo -e "${GREEN}✓ Config directory permissions repaired${NC}"

--- a/scripts/fix-systemd.sh
+++ b/scripts/fix-systemd.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to repair existing Micromanager systemd units that used the `ptty` typo.
+# It searches for unit files containing "ptty" and renames/reloads them with
+# the correct "tty" naming.
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [[ $EUID -ne 0 ]]; then
+  echo -e "${RED}This script must be run as root${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Checking for misnamed systemd units...${NC}"
+
+shopt -s nullglob
+for file in /etc/systemd/system/micromanager@ptty*.service; do
+  corrected="${file/ptty/tty}"
+  echo -e "${YELLOW}Fixing ${file} -> ${corrected}${NC}"
+  sed -i 's/ptty/tty/g' "$file"
+  mv "$file" "$corrected"
+  systemctl disable "$(basename "$file" .service)" >/dev/null 2>&1 || true
+  systemctl enable "$(basename "$corrected" .service)" >/dev/null 2>&1 || true
+  systemctl restart "$(basename "$corrected" .service)" >/dev/null 2>&1 || true
+  echo -e "${GREEN}✓ Corrected and restarted $(basename "$corrected")${NC}"
+
+done
+
+systemctl daemon-reload
+
+echo -e "${GREEN}Systemd units updated.${NC}"

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('Micromanager installed. Run scripts/dual-setup.sh to configure dual instances.');

--- a/src/utils/DeviceInitializer.js
+++ b/src/utils/DeviceInitializer.js
@@ -5,10 +5,10 @@ const logger = require('./Logger');
 
 /**
  * DeviceInitializer - Handles device configuration and ID generation
- * Generates special format device IDs: mmd-rv1-{last6MAC}
+ * Generates device IDs in format: mmd-rv1-{last6MAC}-{port}
  */
 class DeviceInitializer {
-  static configPath = path.join(__dirname, '..', '..', 'config', 'device.json');
+  static configPath = path.join(process.cwd(), 'config', 'device.json');
 
   /**
    * Get or create device configuration
@@ -60,7 +60,8 @@ class DeviceInitializer {
    */
   static async createNewConfig() {
     const macAddress = await this.getMacAddress();
-    const deviceId = this.generateDeviceId(macAddress);
+    const serialPort = process.env.SERIAL_PORT || '/dev/ttyUSB0';
+    const deviceId = this.generateDeviceId(macAddress, serialPort);
 
     const config = {
       deviceId,
@@ -68,7 +69,7 @@ class DeviceInitializer {
       posType: process.env.POS_TYPE || 'verifone_commander',
       n8nWebhookUrl: process.env.N8N_WEBHOOK_URL || '',
       frigateUrl: process.env.FRIGATE_URL || '',
-      serialPort: process.env.SERIAL_PORT || '/dev/ttyUSB0',
+      serialPort,
       serialBaudRate: parseInt(process.env.SERIAL_BAUD_RATE) || 9600,
       localBackupEnabled: true,
       retryAttempts: parseInt(process.env.RETRY_ATTEMPTS) || 3,
@@ -89,14 +90,17 @@ class DeviceInitializer {
   }
 
   /**
-   * Generate device ID in format: mmd-rv1-{last6MAC}
+   * Generate device ID in format: mmd-rv1-{last6MAC}-{port}
    * @param {string} macAddress - MAC address (e.g., "aa:bb:cc:dd:ee:ff")
-   * @returns {string} Device ID (e.g., "mmd-rv1-ddeeff")
+   * @param {string} serialPort - Serial port path (e.g., "/dev/ttyUSB0")
+   * @returns {string} Device ID (e.g., "mmd-rv1-ddeeff-0")
    */
-  static generateDeviceId(macAddress) {
+  static generateDeviceId(macAddress, serialPort = '/dev/ttyUSB0') {
     const cleanMac = macAddress.replace(/[:-]/g, '').toLowerCase();
     const last6Digits = cleanMac.slice(-6);
-    return `mmd-rv1-${last6Digits}`;
+    const match = serialPort.match(/ttyUSB(\d+)/);
+    const portSuffix = match ? match[1] : '0';
+    return `mmd-rv1-${last6Digits}-${portSuffix}`;
   }
 
   /**
@@ -206,7 +210,7 @@ class DeviceInitializer {
     }
 
     // Validate device ID format
-    if (!config.deviceId.match(/^mmd-rv1-[a-f0-9]{6}$/)) {
+    if (!config.deviceId.match(/^mmd-rv1-[a-f0-9]{6}-\d+$/)) {
       logger.warn('Invalid device ID format', { deviceId: config.deviceId });
       return false;
     }
@@ -220,6 +224,12 @@ class DeviceInitializer {
     }
     if (process.env.FRIGATE_URL) {
       config.frigateUrl = process.env.FRIGATE_URL;
+    }
+    if (process.env.SERIAL_PORT) {
+      config.serialPort = process.env.SERIAL_PORT;
+    }
+    if (process.env.SERIAL_BAUD_RATE) {
+      config.serialBaudRate = parseInt(process.env.SERIAL_BAUD_RATE);
     }
 
     return true;

--- a/tests/unit/DeviceInitializer.test.js
+++ b/tests/unit/DeviceInitializer.test.js
@@ -39,26 +39,26 @@ describe('DeviceInitializer', () => {
   describe('generateDeviceId', () => {
     test('should generate correct device ID format from MAC address', () => {
       const macAddress = 'aa:bb:cc:dd:ee:ff';
-      const deviceId = DeviceInitializer.generateDeviceId(macAddress);
-      expect(deviceId).toBe('mmd-rv1-ddeeff');
+      const deviceId = DeviceInitializer.generateDeviceId(macAddress, '/dev/ttyUSB0');
+      expect(deviceId).toBe('mmd-rv1-ddeeff-0');
     });
 
     test('should handle MAC address with dashes', () => {
       const macAddress = 'aa-bb-cc-dd-ee-ff';
-      const deviceId = DeviceInitializer.generateDeviceId(macAddress);
-      expect(deviceId).toBe('mmd-rv1-ddeeff');
+      const deviceId = DeviceInitializer.generateDeviceId(macAddress, '/dev/ttyUSB0');
+      expect(deviceId).toBe('mmd-rv1-ddeeff-0');
     });
 
     test('should handle uppercase MAC address', () => {
       const macAddress = 'AA:BB:CC:DD:EE:FF';
-      const deviceId = DeviceInitializer.generateDeviceId(macAddress);
-      expect(deviceId).toBe('mmd-rv1-ddeeff');
+      const deviceId = DeviceInitializer.generateDeviceId(macAddress, '/dev/ttyUSB0');
+      expect(deviceId).toBe('mmd-rv1-ddeeff-0');
     });
 
     test('should handle mixed case MAC address', () => {
       const macAddress = 'aA:Bb:cC:Dd:Ee:Ff';
-      const deviceId = DeviceInitializer.generateDeviceId(macAddress);
-      expect(deviceId).toBe('mmd-rv1-ddeeff');
+      const deviceId = DeviceInitializer.generateDeviceId(macAddress, '/dev/ttyUSB0');
+      expect(deviceId).toBe('mmd-rv1-ddeeff-0');
     });
   });
 
@@ -140,7 +140,7 @@ describe('DeviceInitializer', () => {
   describe('validateConfig', () => {
     test('should validate correct configuration', () => {
       const config = {
-        deviceId: 'mmd-rv1-ddeeff',
+        deviceId: 'mmd-rv1-ddeeff-0',
         deviceName: 'Test POS',
         posType: 'verifone_commander',
         serialPort: '/dev/ttyUSB0',
@@ -167,7 +167,7 @@ describe('DeviceInitializer', () => {
 
     test('should reject missing required fields', () => {
       const config = {
-        deviceId: 'mmd-rv1-ddeeff',
+        deviceId: 'mmd-rv1-ddeeff-0',
         // Missing deviceName
         posType: 'verifone_commander',
         serialPort: '/dev/ttyUSB0',
@@ -187,7 +187,7 @@ describe('DeviceInitializer', () => {
   describe('getOrCreateConfig', () => {
     test('should load existing valid configuration', async () => {
       const existingConfig = {
-        deviceId: 'mmd-rv1-ddeeff',
+        deviceId: 'mmd-rv1-ddeeff-0',
         deviceName: 'Existing POS',
         posType: 'verifone_commander',
         serialPort: '/dev/ttyUSB0',
@@ -200,7 +200,7 @@ describe('DeviceInitializer', () => {
 
       const config = await DeviceInitializer.getOrCreateConfig();
       
-      expect(config.deviceId).toBe('mmd-rv1-ddeeff');
+      expect(config.deviceId).toBe('mmd-rv1-ddeeff-0');
       // Environment variable should override the config
       expect(config.deviceName).toBe('Test POS'); // From process.env.DEVICE_NAME
       expect(fs.readFile).toHaveBeenCalledWith(mockConfigPath, 'utf8');
@@ -225,7 +225,7 @@ describe('DeviceInitializer', () => {
 
       const config = await DeviceInitializer.getOrCreateConfig();
       
-      expect(config.deviceId).toBe('mmd-rv1-ddeeff');
+      expect(config.deviceId).toBe('mmd-rv1-ddeeff-0');
       expect(config.deviceName).toBe('Test POS');
       expect(config.posType).toBe('verifone_commander');
       expect(config.n8nWebhookUrl).toBe('https://test.n8n.com/webhook');
@@ -258,7 +258,7 @@ describe('DeviceInitializer', () => {
 
       const config = await DeviceInitializer.getOrCreateConfig();
       
-      expect(config.deviceId).toBe('mmd-rv1-ddeeff');
+      expect(config.deviceId).toBe('mmd-rv1-ddeeff-0');
       expect(config.deviceName).toBe('Test POS');
       expect(fs.writeFile).toHaveBeenCalled();
     });
@@ -267,7 +267,7 @@ describe('DeviceInitializer', () => {
   describe('updateConfig', () => {
     test('should update existing configuration', async () => {
       const existingConfig = {
-        deviceId: 'mmd-rv1-ddeeff',
+        deviceId: 'mmd-rv1-ddeeff-0',
         deviceName: 'Test POS',
         posType: 'verifone_commander',
         serialPort: '/dev/ttyUSB0',
@@ -289,7 +289,7 @@ describe('DeviceInitializer', () => {
       
       expect(updatedConfig.n8nWebhookUrl).toBe('https://new.n8n.com/webhook');
       expect(updatedConfig.retryAttempts).toBe(5);
-      expect(updatedConfig.deviceId).toBe('mmd-rv1-ddeeff'); // Preserved
+      expect(updatedConfig.deviceId).toBe('mmd-rv1-ddeeff-0'); // Preserved
       expect(updatedConfig.updatedAt).toBeDefined();
       expect(fs.writeFile).toHaveBeenCalled();
     });

--- a/tests/unit/SimplifiedMicromanager.test.js
+++ b/tests/unit/SimplifiedMicromanager.test.js
@@ -16,7 +16,7 @@ describe('SimplifiedMicromanager', () => {
     jest.clearAllMocks();
     
     mockConfig = {
-      deviceId: 'mmd-rv1-ddeeff',
+      deviceId: 'mmd-rv1-ddeeff-0',
       deviceName: 'Test POS',
       posType: 'verifone_commander',
       n8nWebhookUrl: 'https://test.n8n.com/webhook',
@@ -38,7 +38,7 @@ describe('SimplifiedMicromanager', () => {
 
   describe('constructor', () => {
     test('should initialize with correct configuration', () => {
-      expect(micromanager.deviceId).toBe('mmd-rv1-ddeeff');
+      expect(micromanager.deviceId).toBe('mmd-rv1-ddeeff-0');
       expect(micromanager.deviceName).toBe('Test POS');
       expect(micromanager.posType).toBe('verifone_commander');
       expect(micromanager.n8nWebhookUrl).toBe('https://test.n8n.com/webhook');
@@ -50,7 +50,7 @@ describe('SimplifiedMicromanager', () => {
 
     test('should use default values for optional config', () => {
       const minimalConfig = {
-        deviceId: 'mmd-rv1-test',
+        deviceId: 'mmd-rv1-test-0',
         deviceName: 'Minimal POS',
         posType: 'verifone_commander',
         serialPort: '/dev/ttyUSB0',
@@ -82,7 +82,7 @@ describe('SimplifiedMicromanager', () => {
         expect.objectContaining({
           raw_line: verifoneData, // Exact match - no cleaning!
           line_length: verifoneData.length,
-          micromanager_id: 'mmd-rv1-ddeeff',
+          micromanager_id: 'mmd-rv1-ddeeff-0',
           device_name: 'Test POS',
           pos_type: 'verifone_commander'
         })
@@ -137,7 +137,7 @@ describe('SimplifiedMicromanager', () => {
 
   // Define mockPayload at describe level for shared access
   const mockPayload = {
-    micromanager_id: 'mmd-rv1-ddeeff',
+    micromanager_id: 'mmd-rv1-ddeeff-0',
     device_name: 'Test POS',
     pos_type: 'verifone_commander',
     raw_line: 'test data',
@@ -158,7 +158,7 @@ describe('SimplifiedMicromanager', () => {
           method: 'POST',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            'X-Device-ID': 'mmd-rv1-ddeeff',
+            'X-Device-ID': 'mmd-rv1-ddeeff-0',
             'X-Device-Name': 'Test POS',
             'X-POS-Type': 'verifone_commander'
           }),
@@ -271,7 +271,7 @@ describe('SimplifiedMicromanager', () => {
       const existingData = [
         {
           timestamp: '2025-01-15T09:00:00.000Z',
-          deviceId: 'mmd-rv1-ddeeff',
+          deviceId: 'mmd-rv1-ddeeff-0',
           deviceName: 'Test POS',
           data: { existing: 'data' }
         }
@@ -333,7 +333,7 @@ describe('SimplifiedMicromanager', () => {
       const status = micromanager.getStatus();
 
       expect(status).toMatchObject({
-        deviceId: 'mmd-rv1-ddeeff',
+        deviceId: 'mmd-rv1-ddeeff-0',
         deviceName: 'Test POS',
         posType: 'verifone_commander',
         isOnline: true,


### PR DESCRIPTION
## Summary
- generate device IDs with MAC plus TTY port to keep dual instances unique
- default dual-setup env files to new n8n webhook endpoint and document port-based ID format

## Testing
- `npm install`
- `npm test` *(fails: 7 failed, 43 passed, 50 total)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980ae6bdac8324916ff9d1ab73059d