### PR TITLE
Add dialout supplementary group to service unit template

### DIFF
--- a/scripts/dual-setup.sh
+++ b/scripts/dual-setup.sh
@@ -46,6 +46,7 @@ After=network.target
 Type=simple
 User=micromanager
 Group=micromanager
+SupplementaryGroups=dialout
 WorkingDirectory=/opt/micromanager-%i
 ExecStart=/usr/bin/node app/src/app.js
 EnvironmentFile=/etc/micromanager/%i.env


### PR DESCRIPTION
## Summary
- ensure micromanager service runs with dialout group for serial access by adding `SupplementaryGroups=dialout`

## Testing
- `./scripts/dual-setup.sh` *(fails: System has not been booted with systemd as init system (PID 1))*
- `npx jest --runInBand` *(fails: 7 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899e8bf5bec832485d52988a27e38b2