### PR TITLE
chore: make dual-setup webhook URL configurable and log actual URL

### DIFF
--- a/scripts/dual-setup.sh
+++ b/scripts/dual-setup.sh
@@ -18,6 +18,11 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_DIR="/etc/micromanager"
 SERVICE_TEMPLATE="/etc/systemd/system/micromanager@.service"
 
+# Webhook URL configuration
+# Prefer environment N8N_WEBHOOK_URL if set; otherwise use the standard URL.
+N8N_URL_DEFAULT="https://n8n-vcni0-u35184.vm.elestio.app/webhook/parse-pos-line"
+N8N_URL="${N8N_WEBHOOK_URL:-$N8N_URL_DEFAULT}"
+
 echo -e "${BLUE}=== Micromanager Dual Instance Setup ===${NC}"
 
 # Root check
@@ -77,7 +82,7 @@ for PORT in "${PORTS[@]}"; do
   if [[ ! -f "$ENV_FILE" ]]; then
     cat > "$ENV_FILE" <<ENVEOF
 SERIAL_PORT=/dev/$PORT
-N8N_WEBHOOK_URL=https://n8n-vcni0-u35184.vm.elestio.app/webhook/parse-pos-line
+N8N_WEBHOOK_URL=$N8N_URL
 DEVICE_NAME=register-$PORT
 ENVEOF
     echo -e "${GREEN}✓ Created $ENV_FILE${NC}"

--- a/src/SimplifiedMicromanager.js
+++ b/src/SimplifiedMicromanager.js
@@ -207,7 +207,11 @@ class SimplifiedMicromanager {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        let bodyText = '';
+        try { bodyText = await response.text(); } catch (_) {}
+        const err = new Error(`HTTP ${response.status}: ${response.statusText}`);
+        err.responseBody = bodyText;
+        throw err;
       }
 
       this.stats.webhooksSent++;
@@ -234,6 +238,7 @@ class SimplifiedMicromanager {
       logger.warn(`n8n webhook send attempt ${attempt} failed`, {
         deviceId: this.deviceId,
         error: error.message,
+        responseBody: error.responseBody,
         attempt,
         maxAttempts: this.retryAttempts
       });

--- a/src/app.js
+++ b/src/app.js
@@ -25,7 +25,8 @@ async function main() {
       deviceId: config.deviceId,
       deviceName: config.deviceName,
       posType: config.posType,
-      hasWebhookUrl: !!config.n8nWebhookUrl
+      hasWebhookUrl: !!config.n8nWebhookUrl,
+      n8nWebhookUrl: config.n8nWebhookUrl || '(not set)'
     });
 
     // Create and start micromanager


### PR DESCRIPTION
This PR makes it easier to verify and control the n8n webhook URL for dual-instance deployments and improves diagnostics.

Changes
- dual-setup: Use N8N_WEBHOOK_URL from the shell if set; otherwise default to the Elestio URL. Writes the chosen value into /etc/micromanager/<port>.env.
- startup log: Log the actual n8nWebhookUrl at app start so operators can confirm which URL is used.
- webhook errors: Include response body text in logs for non-200 responses (e.g., 403) to reveal upstream reasons.

Why
- Reduces misconfiguration risk where service instances point to the wrong webhook.
- Speeds up troubleshooting by surfacing the exact URL and any error payload from n8n.

Notes
- No behavior change for existing setups unless N8N_WEBHOOK_URL is exported when running scripts/dual-setup.sh. Defaults continue to target the Elestio URL.

Test Plan
- Verified app logs show n8nWebhookUrl on startup.
- Confirmed dual-setup writes the expected URL into /etc/micromanager/ttyUSB{0,1}.env.
- Simulated 4xx to confirm responseBody is logged.